### PR TITLE
Fix fetch signature

### DIFF
--- a/src/Services/AbstractService.php
+++ b/src/Services/AbstractService.php
@@ -35,7 +35,7 @@ abstract class AbstractService
         string $resourceId,
         array $selections = [],
         string $apiKey = null,
-        bool $forceUseTornProxy
+        bool $forceUseTornProxy = false
     ): array {
         $resource = $this->resourceName . '/' . $resourceId;
 


### PR DESCRIPTION
Fetch signature has a mandatory `$forceUseTornProxy` argument. It shouldn't be mandatory and should default to `false`